### PR TITLE
default theme single.php: only generate <img> when the post actually has an image

### DIFF
--- a/themes/default/single.php
+++ b/themes/default/single.php
@@ -1,7 +1,14 @@
 <?php get_header($post->title, $post->excerpt); ?>
 
 <article>
-	<img src="<?= $post->image; ?>" alt="<?= $post->title; ?>">
+	<?php
+		if (!empty($post->image)) {
+			printf('<img src="%s" alt="%s">',
+				$post->image,
+				$post->title
+			);
+		}
+	?>
 	
 	<h1><?= $post->title; ?></h1>	
 	<p class="lead">Posted on <?= date($config['date_format'], $post->date); ?> • Filed under <?= display_tag_list($post->tags); ?>


### PR DESCRIPTION
Using the default theme, rendering a post without an `image` property generates an ugly empty box, because an <img> tag with `src=""` is generated.

This change makes the <img> conditional, so it's not generated when a post has no `image`.