### PR TITLE
Generate og: properties

### DIFF
--- a/app/frontend.php
+++ b/app/frontend.php
@@ -18,7 +18,7 @@ function get_theme_directory_url() {
 	return $config['base_url'] . '/themes/' . $config['frontend_theme'];
 }
 
-function get_header($title = null, $description = null) {
+function get_header($title = null, $description = null, $image = null) {
 	$config = include('config.php'); 
 	
 	if($title == null) {

--- a/themes/default/header.php
+++ b/themes/default/header.php
@@ -5,6 +5,14 @@
 	<meta charset="UTF-8">
 	<meta name="description" content="<?= $description; ?>">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta property="og:title" content="<?= $title; ?>">
+	<meta property="og:description" content="<?= $description; ?>">
+	<meta property="og:type" content="website">
+	<?php
+		if (!empty($image)) {
+			printf('<meta property="og:image" content="%s">', $image);
+		}
+	?>
 
 	<link rel="stylesheet" href="<?= get_theme_directory_url(); ?>/assets/normalize.min.css" type="text/css">	
 	<link rel="stylesheet" href="<?= get_theme_directory_url(); ?>/assets/styles.css" type="text/css">

--- a/themes/default/single.php
+++ b/themes/default/single.php
@@ -1,4 +1,4 @@
-<?php get_header($post->title, $post->excerpt); ?>
+<?php get_header($post->title, $post->excerpt, $post->image); ?>
 
 <article>
 	<img src="<?= $post->image; ?>" alt="<?= $post->title; ?>">


### PR DESCRIPTION
Make the default theme's header.php generate the <meta> properties og: title, description, type, image.

This change enables Twitter to show "cards" for tweets that link to nicholas posts. It might also work for *acebook, but I haven't tested that. (ref. https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/abouts-cards )

header.php needs to know the image url for the og:image property, so this PR also adds `image` as third argument for get_header().
